### PR TITLE
Add validity test for coordinates to avoid geopy errors

### DIFF
--- a/pyfuelprices/sources/switzerland/comparis.py
+++ b/pyfuelprices/sources/switzerland/comparis.py
@@ -97,6 +97,13 @@ class ComparisSource(Source):
 
     def _parse_raw(self, station: dict) -> FuelLocation:
         """Parse a single raw instance of a fuel site."""
+        #Coord Check
+        lat = station["location"]["lat"]
+        lng = station["location"]["lng"]
+        if lat <-90 or lat > 90 or lng <-180 or lng > 180:
+            return False
+        
+
         site_id = f"{self.provider_name}_{station['id']}"
         _LOGGER.debug("Parsing Comparis location ID %s", site_id)
         plz_pattern = r'\d{4}'
@@ -130,10 +137,11 @@ class ComparisSource(Source):
     async def parse_response(self, response) -> list[FuelLocation]:
         for station_raw in response:
             station = self._parse_raw(station_raw)
-            if station.id not in self.location_cache:
-                self.location_cache[station.id] = station
-            else:
-                await self.location_cache[station.id].update(station)
+            if station != False: #If station information is not valid, then ret val is set to False
+                if station.id not in self.location_cache:
+                    self.location_cache[station.id] = station
+                else:
+                    await self.location_cache[station.id].update(station)
         return list(self.location_cache.values())
 
     def parse_fuels(self, fuels: dict[str, object]) -> list[Fuel]:

--- a/pyfuelprices/sources/switzerland/comparis.py
+++ b/pyfuelprices/sources/switzerland/comparis.py
@@ -101,8 +101,7 @@ class ComparisSource(Source):
         lat = station["location"]["lat"]
         lng = station["location"]["lng"]
         if lat <-90 or lat > 90 or lng <-180 or lng > 180:
-            return False
-        
+            return None
 
         site_id = f"{self.provider_name}_{station['id']}"
         _LOGGER.debug("Parsing Comparis location ID %s", site_id)
@@ -137,7 +136,7 @@ class ComparisSource(Source):
     async def parse_response(self, response) -> list[FuelLocation]:
         for station_raw in response:
             station = self._parse_raw(station_raw)
-            if station != False: #If station information is not valid, then ret val is set to False
+            if station: #If station information is not valid, then none is returned
                 if station.id not in self.location_cache:
                     self.location_cache[station.id] = station
                 else:


### PR DESCRIPTION
Because of the latest fix, there is a error because one station from the data provider is missing the decimal dot in the coordinates. Therefore geopy throws an error when using the comparis data source. I implemented a small validity check of the coordinates.

@pantherale0 Maybe this should be something that could be done for all sources? Check the validity of some points (Coordinates, empty names, no ids, etc.)