### PR TITLE
Fix fuel cost calculation in PetrolSpySource by converting amount to dollars

### DIFF
--- a/pyfuelprices/sources/australia/petrolspy.py
+++ b/pyfuelprices/sources/australia/petrolspy.py
@@ -117,7 +117,7 @@ class PetrolSpySource(Source):
             f = fuels[k]
             output.append(Fuel(
                 fuel_type=k,
-                cost=f["amount"],
+                cost=f["amount"]/100,
                 props=f
             ))
         return output


### PR DESCRIPTION
Adjust the fuel cost calculation in PetrolSpy to ensure that the amount is correctly converted from cents to dollars. This change addresses the issue of incorrect unit representation for fuel prices.

Fixes #38