### PR TITLE
Update area property constants to match Home Assistant

### DIFF
--- a/pyfuelprices/const.py
+++ b/pyfuelprices/const.py
@@ -5,8 +5,8 @@ PROP_FUEL_LOCATION_SOURCE = "source"
 PROP_FUEL_LOCATION_SOURCE_ID = "source_id"
 PROP_FUEL_LOCATION_PREVENT_CACHE_CLEANUP = "prevent_cache_cleanup"
 
-PROP_AREA_LAT = "lat"
-PROP_AREA_LONG = "long"
+PROP_AREA_LAT = "latitude"
+PROP_AREA_LONG = "longitude"
 PROP_AREA_RADIUS = "radius"
 
 


### PR DESCRIPTION
Change area property constants to align with Home Assistant's naming conventions.