### PR TITLE
Add Italy (MIMIT Open Data CSV) fuel source

### DIFF
--- a/pyfuelprices/sources/italy/__init__.py
+++ b/pyfuelprices/sources/italy/__init__.py
@@ -1,0 +1,1 @@
+"""Italy fuel price sources."""

--- a/pyfuelprices/sources/italy/const.py
+++ b/pyfuelprices/sources/italy/const.py
@@ -1,0 +1,43 @@
+"""Italy (MIMIT Open Data CSV) constants.
+
+Il MIMIT pubblica ogni giorno due file CSV pubblici aggiornati alle ore 8:
+  - anagrafica: contiene i dati di ogni distributore (posizione, nome, ecc.)
+  - prezzi:     contiene i prezzi comunicati dai gestori
+
+Fonte: https://www.mimit.gov.it/it/open-data/elenco-dataset/carburanti-prezzi-praticati-e-anagrafica-degli-impianti
+"""
+
+# URL del file CSV con i prezzi del giorno (aggiornato ogni mattina alle 8)
+MISE_PRICES_CSV_URL = (
+    "https://www.mimit.gov.it/images/exportCSV/prezzo_alle_8.csv"
+)
+
+# URL del file CSV con l'anagrafica di tutti gli impianti attivi
+MISE_STATIONS_CSV_URL = (
+    "https://www.mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv"
+)
+
+# Dal 10 febbraio 2026 il separatore di campo è "|" (pipe)
+MISE_CSV_SEPARATOR = "|"
+
+# Header HTTP per sembrare un browser normale
+MISE_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,*/*",
+    "Referer": "https://www.mimit.gov.it/",
+}
+
+# Mapping dai nomi carburante del MISE ai codici standard di pyfuelprices
+MISE_FUEL_MAPPING = {
+    "Benzina":          "BENZINA",   # SP95 / E10
+    "Gasolio":          "GASOLIO",   # Diesel B7
+    "GPL":              "GPL",       # Autogas LPG
+    "Metano":           "METANO",    # CNG
+    "Metano L-GNC":     "LGNC",      # Metano liquefatto rigassificato
+    "GNL":              "GNL",       # Gas Naturale Liquefatto
+    "HVO":              "HVO",       # Olio vegetale idrotrattato
+}

--- a/pyfuelprices/sources/italy/mise.py
+++ b/pyfuelprices/sources/italy/mise.py
@@ -1,0 +1,249 @@
+"""Italy MIMIT Open Data CSV source per pyfuelprices.
+
+Come funziona:
+  Il MIMIT pubblica ogni mattina alle 8 due file CSV pubblici:
+    1. anagrafica_impianti_attivi.csv  ->  posizione e dati di ogni distributore
+    2. prezzo_alle_8.csv               ->  prezzi comunicati dai gestori
+
+  Questo modulo scarica entrambi i file, li unisce tramite l'ID impianto,
+  e costruisce la lista di FuelLocation compatibile con pyfuelprices.
+"""
+
+import logging
+import io
+import csv
+import math
+from datetime import timedelta, datetime
+
+from pyfuelprices.const import (
+    PROP_FUEL_LOCATION_SOURCE,
+    PROP_FUEL_LOCATION_PREVENT_CACHE_CLEANUP,
+    PROP_FUEL_LOCATION_SOURCE_ID,
+    PROP_AREA_LAT,
+    PROP_AREA_LONG,
+    PROP_AREA_RADIUS,
+)
+from pyfuelprices.sources import Source
+from pyfuelprices.fuel_locations import Fuel, FuelLocation
+
+from .const import (
+    MISE_PRICES_CSV_URL,
+    MISE_STATIONS_CSV_URL,
+    MISE_CSV_SEPARATOR,
+    MISE_HEADERS,
+    MISE_FUEL_MAPPING,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_KM_PER_MILE = 1.60934
+
+
+def _haversine_km(lat1, lon1, lat2, lon2) -> float:
+    """Calcola la distanza in km tra due coordinate geografiche."""
+    R = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (math.sin(dlat / 2) ** 2
+         + math.cos(math.radians(lat1))
+         * math.cos(math.radians(lat2))
+         * math.sin(dlon / 2) ** 2)
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+class MISESource(Source):
+    """Sorgente dati carburanti Italia - MIMIT Open Data CSV.
+
+    Utilizza i file CSV ufficiali pubblicati ogni giorno dal Ministero
+    delle Imprese e del Made in Italy (MIMIT).
+
+    Documentazione:
+      https://www.mimit.gov.it/it/open-data/elenco-dataset/
+      carburanti-prezzi-praticati-e-anagrafica-degli-impianti
+    """
+
+    country_code = "IT"
+    provider_name = "mise_italy"
+
+    _headers = MISE_HEADERS
+    update_interval = timedelta(hours=12)
+
+    location_cache: dict[str, FuelLocation] = {}
+
+    _stations_raw: dict[str, dict] = {}
+    _prices_raw: dict[str, list] = {}
+
+    async def _download_csv(self, url: str) -> str | None:
+        """Scarica un file CSV dall'URL indicato e restituisce il testo."""
+        _LOGGER.debug("MISE Italy: scarico CSV da %s", url)
+        async with self._client_session.get(url, headers=self._headers) as resp:
+            if resp.ok:
+                raw_bytes = await resp.read()
+                try:
+                    return raw_bytes.decode("latin-1")
+                except UnicodeDecodeError:
+                    return raw_bytes.decode("utf-8", errors="replace")
+            _LOGGER.error(
+                "MISE Italy: errore HTTP %s scaricando %s", resp.status, url
+            )
+            return None
+
+    def _parse_stations_csv(self, text: str) -> dict[str, dict]:
+        """Legge il CSV anagrafica e restituisce un dizionario id->dati."""
+        stations = {}
+        lines = text.splitlines()
+        content = "\n".join(lines[1:])
+        reader = csv.DictReader(io.StringIO(content), delimiter=MISE_CSV_SEPARATOR)
+        for row in reader:
+            sid = row.get("idImpianto", "").strip()
+            if not sid:
+                continue
+            try:
+                lat = float(row.get("Latitudine", "0").replace(",", "."))
+                lon = float(row.get("Longitudine", "0").replace(",", "."))
+            except ValueError:
+                lat, lon = 0.0, 0.0
+            stations[sid] = {
+                "id":        sid,
+                "gestore":   row.get("Gestore", "").strip(),
+                "bandiera":  row.get("Bandiera", "").strip(),
+                "nome":      row.get("Nome Impianto", "").strip(),
+                "indirizzo": row.get("Indirizzo", "").strip(),
+                "comune":    row.get("Comune", "").strip(),
+                "provincia": row.get("Provincia", "").strip(),
+                "lat":       lat,
+                "lon":       lon,
+            }
+        _LOGGER.debug("MISE Italy: lette %d stazioni dall'anagrafica", len(stations))
+        return stations
+
+    def _parse_prices_csv(self, text: str) -> dict[str, list]:
+        """Legge il CSV prezzi e restituisce un dizionario id->lista prezzi."""
+        prices: dict[str, list] = {}
+        lines = text.splitlines()
+        content = "\n".join(lines[1:])
+        reader = csv.DictReader(io.StringIO(content), delimiter=MISE_CSV_SEPARATOR)
+        for row in reader:
+            sid = row.get("idImpianto", "").strip()
+            if not sid:
+                continue
+            try:
+                price = float(row.get("prezzo", "0").replace(",", "."))
+            except ValueError:
+                continue
+            if price <= 0:
+                continue
+            prices.setdefault(sid, []).append({
+                "descCarburante": row.get("descCarburante", "").strip(),
+                "prezzo":         price,
+                "isSelf":         row.get("isSelf", "0").strip() == "1",
+            })
+        _LOGGER.debug("MISE Italy: letti prezzi per %d stazioni", len(prices))
+        return prices
+
+    async def update(self, areas=None, force=False) -> list[FuelLocation]:
+        """Scarica i due CSV e aggiorna la cache completa."""
+        if self.next_update > datetime.now() and not force:
+            _LOGGER.debug("MISE Italy: aggiornamento non necessario")
+            return list(self.location_cache.values())
+
+        _LOGGER.debug("MISE Italy: avvio aggiornamento dati")
+
+        stations_text = await self._download_csv(MISE_STATIONS_CSV_URL)
+        prices_text   = await self._download_csv(MISE_PRICES_CSV_URL)
+
+        if stations_text is None or prices_text is None:
+            _LOGGER.error("MISE Italy: impossibile scaricare i CSV, aggiornamento saltato")
+            return list(self.location_cache.values())
+
+        self._stations_raw = self._parse_stations_csv(stations_text)
+        self._prices_raw   = self._parse_prices_csv(prices_text)
+
+        for sid, station in self._stations_raw.items():
+            if sid not in self._prices_raw:
+                continue
+            if station["lat"] == 0.0 and station["lon"] == 0.0:
+                continue
+
+            loc = self._build_location(station, self._prices_raw[sid])
+            if loc.id not in self.location_cache:
+                self.location_cache[loc.id] = loc
+            else:
+                await self.location_cache[loc.id].update(loc)
+
+        self.next_update = datetime.now() + self.update_interval
+        _LOGGER.debug(
+            "MISE Italy: cache aggiornata con %d stazioni", len(self.location_cache)
+        )
+        return list(self.location_cache.values())
+
+    async def search_sites(self, coordinates, radius: float) -> list[dict]:
+        """Restituisce le stazioni nel raggio (in miglia) dalle coordinate date."""
+        if not self.location_cache:
+            await self.update(force=True)
+
+        radius_km = radius * _KM_PER_MILE
+        results = []
+        for loc in self.location_cache.values():
+            dist_km = _haversine_km(
+                coordinates[0], coordinates[1], loc.lat, loc.long
+            )
+            if dist_km <= radius_km:
+                await loc.dynamic_build_fuels()
+                results.append({**loc.__dict__, "distance": dist_km / _KM_PER_MILE})
+        return results
+
+    async def update_area(self, area: dict) -> bool:
+        """Richiesto dalla classe base; deleghiamo tutto a update()."""
+        await self.update()
+        return True
+
+    async def parse_response(self, response) -> list[FuelLocation]:
+        """Non usato in questa implementazione."""
+        return list(self.location_cache.values())
+
+    def _build_location(self, station: dict, raw_prices: list) -> FuelLocation:
+        """Crea un oggetto FuelLocation dai dati di una stazione."""
+        site_id = f"{self.provider_name}_{station['id']}"
+        brand   = station["bandiera"] or station["gestore"]
+        name    = station["nome"] or brand
+        address = ", ".join(filter(None, [
+            station["indirizzo"],
+            station["comune"],
+            station["provincia"],
+        ]))
+
+        loc = FuelLocation.create(
+            site_id=site_id,
+            name=name,
+            address=address,
+            lat=station["lat"],
+            long=station["lon"],
+            brand=brand,
+            available_fuels=self.parse_fuels(raw_prices),
+            postal_code="",
+            currency="EUR",
+            props={
+                PROP_FUEL_LOCATION_SOURCE:                self.provider_name,
+                PROP_FUEL_LOCATION_SOURCE_ID:             station["id"],
+                PROP_FUEL_LOCATION_PREVENT_CACHE_CLEANUP: True,
+            },
+        )
+        loc.next_update = (
+            self.next_update
+            if self.next_update > datetime.now()
+            else self.next_update + self.update_interval
+        )
+        return loc
+
+    def parse_fuels(self, raw_prices: list) -> list[Fuel]:
+        """Converte la lista prezzi in oggetti Fuel, preferendo il self-service."""
+        best: dict[str, float] = {}
+        for entry in raw_prices:
+            raw_name = entry.get("descCarburante", "")
+            fuel_key = MISE_FUEL_MAPPING.get(raw_name, raw_name.upper())
+            price    = entry.get("prezzo", 0.0)
+            is_self  = entry.get("isSelf", False)
+            if fuel_key not in best or is_self:
+                best[fuel_key] = price
+        return [Fuel(fuel_type=k, cost=v, props={}) for k, v in best.items()]

--- a/pyfuelprices/sources/italy/mise.py
+++ b/pyfuelprices/sources/italy/mise.py
@@ -19,9 +19,6 @@ from pyfuelprices.const import (
     PROP_FUEL_LOCATION_SOURCE,
     PROP_FUEL_LOCATION_PREVENT_CACHE_CLEANUP,
     PROP_FUEL_LOCATION_SOURCE_ID,
-    PROP_AREA_LAT,
-    PROP_AREA_LONG,
-    PROP_AREA_RADIUS,
 )
 from pyfuelprices.sources import Source
 from pyfuelprices.fuel_locations import Fuel, FuelLocation
@@ -35,20 +32,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-_KM_PER_MILE = 1.60934
-
-
-def _haversine_km(lat1, lon1, lat2, lon2) -> float:
-    """Calcola la distanza in km tra due coordinate geografiche."""
-    R = 6371.0
-    dlat = math.radians(lat2 - lat1)
-    dlon = math.radians(lon2 - lon1)
-    a = (math.sin(dlat / 2) ** 2
-         + math.cos(math.radians(lat1))
-         * math.cos(math.radians(lat2))
-         * math.sin(dlon / 2) ** 2)
-    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
 class MISESource(Source):
@@ -68,10 +51,15 @@ class MISESource(Source):
     _headers = MISE_HEADERS
     update_interval = timedelta(hours=12)
 
-    location_cache: dict[str, FuelLocation] = {}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # FIX: location_cache come attributo di istanza, non di classe,
+        # per evitare che due istanze condividano la stessa cache.
+        self.location_cache: dict[str, FuelLocation] = {}
 
-    _stations_raw: dict[str, dict] = {}
-    _prices_raw: dict[str, list] = {}
+    # ------------------------------------------------------------------
+    # Download CSV
+    # ------------------------------------------------------------------
 
     async def _download_csv(self, url: str) -> str | None:
         """Scarica un file CSV dall'URL indicato e restituisce il testo."""
@@ -79,21 +67,34 @@ class MISESource(Source):
         async with self._client_session.get(url, headers=self._headers) as resp:
             if resp.ok:
                 raw_bytes = await resp.read()
+                # FIX: prova prima UTF-8 (encoding piu' moderno e sicuro),
+                # poi latin-1 come fallback. latin-1 non fallisce mai quindi
+                # deve stare per secondo.
                 try:
-                    return raw_bytes.decode("latin-1")
+                    return raw_bytes.decode("utf-8")
                 except UnicodeDecodeError:
-                    return raw_bytes.decode("utf-8", errors="replace")
+                    return raw_bytes.decode("latin-1", errors="replace")
             _LOGGER.error(
                 "MISE Italy: errore HTTP %s scaricando %s", resp.status, url
             )
             return None
 
+    # ------------------------------------------------------------------
+    # Parsing CSV
+    # ------------------------------------------------------------------
+
     def _parse_stations_csv(self, text: str) -> dict[str, dict]:
-        """Legge il CSV anagrafica e restituisce un dizionario id->dati."""
+        """Legge il CSV anagrafica e restituisce un dizionario id->dati.
+
+        Il CSV inizia con una riga di metadati tipo 'Estrazione del 2026-04-12'
+        che viene saltata con next(f) prima di passare al DictReader.
+        """
         stations = {}
-        lines = text.splitlines()
-        content = "\n".join(lines[1:])
-        reader = csv.DictReader(io.StringIO(content), delimiter=MISE_CSV_SEPARATOR)
+        # FIX: uso un iteratore StringIO invece di splitlines()+join(),
+        # evitando di duplicare l'intero CSV in memoria.
+        f = io.StringIO(text)
+        next(f)  # salta la riga "Estrazione del ..."
+        reader = csv.DictReader(f, delimiter=MISE_CSV_SEPARATOR)
         for row in reader:
             sid = row.get("idImpianto", "").strip()
             if not sid:
@@ -103,6 +104,8 @@ class MISESource(Source):
                 lon = float(row.get("Longitudine", "0").replace(",", "."))
             except ValueError:
                 lat, lon = 0.0, 0.0
+            if lat == 0.0 and lon == 0.0:
+                continue
             stations[sid] = {
                 "id":        sid,
                 "gestore":   row.get("Gestore", "").strip(),
@@ -118,11 +121,16 @@ class MISESource(Source):
         return stations
 
     def _parse_prices_csv(self, text: str) -> dict[str, list]:
-        """Legge il CSV prezzi e restituisce un dizionario id->lista prezzi."""
+        """Legge il CSV prezzi e restituisce un dizionario id->lista prezzi.
+
+        Il CSV inizia con una riga di metadati tipo 'Estrazione del 2026-04-12'
+        che viene saltata con next(f) prima di passare al DictReader.
+        """
         prices: dict[str, list] = {}
-        lines = text.splitlines()
-        content = "\n".join(lines[1:])
-        reader = csv.DictReader(io.StringIO(content), delimiter=MISE_CSV_SEPARATOR)
+        # FIX: stessa ottimizzazione memoria del parser anagrafica.
+        f = io.StringIO(text)
+        next(f)  # salta la riga "Estrazione del ..."
+        reader = csv.DictReader(f, delimiter=MISE_CSV_SEPARATOR)
         for row in reader:
             sid = row.get("idImpianto", "").strip()
             if not sid:
@@ -141,6 +149,10 @@ class MISESource(Source):
         _LOGGER.debug("MISE Italy: letti prezzi per %d stazioni", len(prices))
         return prices
 
+    # ------------------------------------------------------------------
+    # pyfuelprices Source interface
+    # ------------------------------------------------------------------
+
     async def update(self, areas=None, force=False) -> list[FuelLocation]:
         """Scarica i due CSV e aggiorna la cache completa."""
         if self.next_update > datetime.now() and not force:
@@ -153,19 +165,19 @@ class MISESource(Source):
         prices_text   = await self._download_csv(MISE_PRICES_CSV_URL)
 
         if stations_text is None or prices_text is None:
-            _LOGGER.error("MISE Italy: impossibile scaricare i CSV, aggiornamento saltato")
+            _LOGGER.error(
+                "MISE Italy: impossibile scaricare i CSV, aggiornamento saltato"
+            )
             return list(self.location_cache.values())
 
-        self._stations_raw = self._parse_stations_csv(stations_text)
-        self._prices_raw   = self._parse_prices_csv(prices_text)
+        stations_raw = self._parse_stations_csv(stations_text)
+        prices_raw   = self._parse_prices_csv(prices_text)
 
-        for sid, station in self._stations_raw.items():
-            if sid not in self._prices_raw:
-                continue
-            if station["lat"] == 0.0 and station["lon"] == 0.0:
+        for sid, station in stations_raw.items():
+            if sid not in prices_raw:
                 continue
 
-            loc = self._build_location(station, self._prices_raw[sid])
+            loc = self._build_location(station, prices_raw[sid])
             if loc.id not in self.location_cache:
                 self.location_cache[loc.id] = loc
             else:
@@ -177,21 +189,9 @@ class MISESource(Source):
         )
         return list(self.location_cache.values())
 
-    async def search_sites(self, coordinates, radius: float) -> list[dict]:
-        """Restituisce le stazioni nel raggio (in miglia) dalle coordinate date."""
-        if not self.location_cache:
-            await self.update(force=True)
-
-        radius_km = radius * _KM_PER_MILE
-        results = []
-        for loc in self.location_cache.values():
-            dist_km = _haversine_km(
-                coordinates[0], coordinates[1], loc.lat, loc.long
-            )
-            if dist_km <= radius_km:
-                await loc.dynamic_build_fuels()
-                results.append({**loc.__dict__, "distance": dist_km / _KM_PER_MILE})
-        return results
+    # FIX: rimosso search_sites personalizzato — la classe base Source
+    # gestisce gia' la ricerca per distanza usando geopy, che e' gia'
+    # una dipendenza del progetto. Sovrascriverlo era ridondante.
 
     async def update_area(self, area: dict) -> bool:
         """Richiesto dalla classe base; deleghiamo tutto a update()."""
@@ -201,6 +201,10 @@ class MISESource(Source):
     async def parse_response(self, response) -> list[FuelLocation]:
         """Non usato in questa implementazione."""
         return list(self.location_cache.values())
+
+    # ------------------------------------------------------------------
+    # Costruzione FuelLocation
+    # ------------------------------------------------------------------
 
     def _build_location(self, station: dict, raw_prices: list) -> FuelLocation:
         """Crea un oggetto FuelLocation dai dati di una stazione."""
@@ -247,3 +251,4 @@ class MISESource(Source):
             if fuel_key not in best or is_self:
                 best[fuel_key] = price
         return [Fuel(fuel_type=k, cost=v, props={}) for k, v in best.items()]
+


### PR DESCRIPTION
This PR adds support for Italy using the official open data published daily
by the Italian Ministry of Enterprises and Made in Italy (MIMIT).

### Data source
- **Stations registry:** https://www.mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv
- **Prices:** https://www.mimit.gov.it/images/exportCSV/prezzo_alle_8.csv
- **License:** IODL 2.0 (open data)
- **Update frequency:** daily at 08:00 AM Italian time

### Fuels supported
Benzina (SP95), Gasolio (Diesel), GPL, Metano (CNG), Metano L-GNC, GNL, HVO

### Implementation notes
Two important quirks discovered during testing that are not obvious from
the official documentation:

1. Each CSV file starts with a header line like `Estrazione del 2026-04-12`
   before the actual column names — this line must be skipped.
2. Since 10 February 2026, the field separator changed from comma to `|` (pipe).

The implementation downloads both CSV files, joins them by `idImpianto`,
filters stations by distance from the configured coordinates, and prefers
self-service prices over attended prices when both are available.

### Tested
Manually tested with coordinates in northern Italy (~20,000 stations loaded,
correct prices returned for nearby stations)